### PR TITLE
Version string change

### DIFF
--- a/export-laravel-5-migrations.py
+++ b/export-laravel-5-migrations.py
@@ -17,7 +17,7 @@ from mforms import newButton, newCodeEditor, FileChooser
 
 ModuleInfo = DefineModule(name='GenerateLaravel5Migration',
                           author='Brandon Eckenrode',
-                          version='0.1.2')
+                          version='0.1.5')
 
 @ModuleInfo.plugin('wb.util.generateLaravel5Migration',
                    caption='Export Laravel 5 Migration',


### PR DESCRIPTION
Your v0.1.4 tag still had a version string in the code of `0.1.2`. Since you shouldn't ever change a tagged release, I didn't update it to `0.1.4`. Instead, I've preemptively updated the version string to `0.1.5`, in preparation for your next tagged release.

Of course, if you jump this version number, you'll just have to remember to update the version string in the code before you tag it.
