### PR TITLE
Correctly set foreign key relations

### DIFF
--- a/export-laravel-5-migrations.py
+++ b/export-laravel-5-migrations.py
@@ -370,13 +370,21 @@ def generate_laravel5_migration(cat):
                                     migrations[ti].append('\n')
                                     first_foreign_created = True
 
+                         	deleteRule = key.deleteRule
+                            	if deleteRule == "":
+                            		deleteRule = "RESTRICT"
+
+                            	updateRule = key.updateRule
+                            	if updateRule == "":
+                            		updateRule = "RESTRICT"
+
                                 migrations[ti].append(foreignKeyTemplate.format(
                                     foreignKey=foreign_key,
                                     foreignKeyName=index_name,
                                     tableKeyName=key.referencedColumns[0].name,
                                     foreignTableName=key.referencedColumns[0].owner.name,
-                                    onDeleteAction=key.deleteRule.lower(),
-                                    onUpdateAction=key.updateRule.lower()
+                                    onDeleteAction=deleteRule.lower(),
+                                    onUpdateAction=updateRule.lower()
                                 ))
 
                             else:

--- a/export-laravel-5-migrations.py
+++ b/export-laravel-5-migrations.py
@@ -370,13 +370,13 @@ def generate_laravel5_migration(cat):
                                     migrations[ti].append('\n')
                                     first_foreign_created = True
 
-                         	deleteRule = key.deleteRule
-                            	if deleteRule == "":
-                            		deleteRule = "RESTRICT"
+                                deleteRule = key.deleteRule
+                                if deleteRule == "":
+                            	    deleteRule = "RESTRICT"
 
-                            	updateRule = key.updateRule
-                            	if updateRule == "":
-                            		updateRule = "RESTRICT"
+                                updateRule = key.updateRule
+                                if updateRule == "":
+                            	    updateRule = "RESTRICT"
 
                                 migrations[ti].append(foreignKeyTemplate.format(
                                     foreignKey=foreign_key,


### PR DESCRIPTION
See https://github.com/beckenrode/mysql-workbench-export-laravel-5-migrations/issues/34

I have a few relationships created where there is no `onUpdate` or `onDelete` action specified in the mysql relationship.

This means that when this workbench creates the migrations, it looks something like this:

```
$table->foreign('order_id', 'product_items_order_id_foreign')
  ->references('id')->on('orders')
  ->onDelete('cascade')
  ->onUpdate(''); // this is the issue
```

And this evaluates to:
```
alter table `product_items`
add constraint product_items_order_id_foreign foreign key (`order_id`)
references `orders` (`id`) 
on delete cascade on update 
```

As you can see, there shouldn't be an `on update` part to the relationship. Alternatively, this can be made `RESTRICT`, as this is what mysql defaults to anyway. So the above migrations can be written as:

```
$table->foreign('order_id', 'product_items_order_id_foreign')
  ->references('id')->on('orders')
  ->onDelete('cascade')
  ->onUpdate('restrict'); // or just leave this out completely
```