### PR TITLE
Database comments can have single quote and slashes, which needs to be adjusted. 

### DIFF
--- a/export-laravel-5-migrations.py
+++ b/export-laravel-5-migrations.py
@@ -177,6 +177,13 @@ def generate_laravel5_migration(cat):
             d = dict(((k, v - t) for k, v in d.items() if v))
         return r
 
+    def addslashes(s):
+        l = ["\\", "'", "\0", ]
+        for i in l:
+            if i in s:
+                s = s.replace(i, '\\'+i)
+        return s
+
     def export_schema(table_schema, tree):
         if len(table_schema.tables) == 0:
             return
@@ -328,7 +335,7 @@ def generate_laravel5_migration(cat):
                                         migrations[ti].append("->default('{}')".format(default_value))
 
                                 if col.comment != '':
-                                    migrations[ti].append("->comment('{comment}')".format(comment=col.comment))
+                                    migrations[ti].append("->comment('{comment}')".format(comment=addslashes(col.comment)))
 
                                 migrations[ti].append(';\n')
 


### PR DESCRIPTION
Database comments can have single quote and slashes, which needs to be escaped. 

Broken migration scripts get generated. Check this screenshot
![screenshot 2017-04-07 11 23 32](https://cloud.githubusercontent.com/assets/3818055/24787219/c81e19b8-1b84-11e7-9aa6-68ec5571f827.png)
