### PR TITLE
making migration classes anonymous

### DIFF
--- a/export-laravel-5-migrations.py
+++ b/export-laravel-5-migrations.py
@@ -146,7 +146,7 @@ indexKeyTemplate = '''
 
 migrationEndingTemplate = '''        Schema::dropIfExists($this->tableName);
     }}
-}}
+}};
 '''
 
 ModuleInfo = DefineModule(

--- a/export-laravel-5-migrations.py
+++ b/export-laravel-5-migrations.py
@@ -96,13 +96,11 @@ migrations = {}
 migration_tables = []
 migrationTemplate = '''<?php
 
-namespace Database\Migrations;
-
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class Create{tableNameCamelCase}Table extends Migration
+return new class extends Migration
 {{
     /**
      * Schema table name to migrate


### PR DESCRIPTION
Laravel 8.37 introduces migration using anonymous classes to solves [the issue](https://github.com/laravel/framework/issues/5899) with migration class name collisions. #86 